### PR TITLE
Update bukkit api in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 
 	@echo "Building Spigot Minecraft server..."
 	cd minecraft && java -jar BuildTools.jar
-	cp minecraft/Bukkit/target/bukkit-1.8-R0.1-SNAPSHOT.jar resources/
+	cp minecraft/Bukkit/target/bukkit-1.8.7-R0.1-SNAPSHOT.jar resources/bukkit-1.8-R0.1-SNAPSHOT.jar
 
 	@echo "Compling clj-minecraft..."
 	lein uberjar


### PR DESCRIPTION
This really shouldn't be hardcoded, what are the thoughts on trying to figure it out automatically somehow?
bukkit-*-SNAPSHOT.jar or such, especially on compile.

Not sure if we should auto-compile the bukkit.jar at all really, instead just tell user to drop a bukkit.jar in resources directory, and point them at the build instructions?
